### PR TITLE
feat: add NKEYs and JWT auth

### DIFF
--- a/spawnpoint.nats.js
+++ b/spawnpoint.nats.js
@@ -59,7 +59,7 @@ module.exports = require('spawnpoint').registerPlugin({
 				// We want to read in the creds file given to us
 				const authCredsFile = path.join(app.cwd, config.connection.auth.creds_file);
 				delete config.connection.auth.creds_file;
-				const authCreds = fs.readFileSync(authCredsFile, 'utf8');
+				const authCreds = fs.readFileSync(authCredsFile);
 				// Create a new credsAuthenticator
 				config.connection.authenticator = nats.credsAuthenticator(authCreds);
 				delete config.connection.auth;

--- a/spawnpoint.nats.js
+++ b/spawnpoint.nats.js
@@ -54,6 +54,17 @@ module.exports = require('spawnpoint').registerPlugin({
 				config.connection.name += ` node@${process.version}`;
 			}
 
+			// Setup an authenticator if available
+			if(config.connection.auth) {
+				// We want to read in the creds file given to us
+				const authCredsFile = path.join(app.cwd, config.connection.auth.creds_file);
+				delete config.connection.auth.creds_file;
+				const authCreds = fs.readFileSync(authCredsFile, 'utf8');
+				// Create a new credsAuthenticator
+				config.connection.authenticator = nats.credsAuthenticator(authCreds);
+				delete config.connection.auth;
+			}
+
 			const helpers = {
 				wrapMessageError(error) {
 					if(error?.code === nats.ErrorCode.NoResponders) {


### PR DESCRIPTION
This adds support for authenticating using NKEYs and JWT following [this part of the nats.js readme.](https://github.com/nats-io/nats.js#authenticators)

This was tested using the following as the `app.js`
```js
'use strict';
const _ = require('lodash');
const spawnpoint = require('spawnpoint');
const app = new spawnpoint();

app.setup();


app.on('app.ready', function() {
	console.log('App is ready');
	// Run the following every 5 seconds
	setInterval(function() {
		// Publish a message to the NATS server
		app.nats.publish("test.1", "I'm test 2!", function() {
			console.log("Message sent!");
		});
	}, 5000);

	// Subscribe to test.1
	app.nats.subscribe("test.2", function(msg) {
		console.log("Received a message on test.2: " + msg);
	});
});
```
And the following as the `nats.json`
```json
{
	"connection": {
		"tls": true,
		"maxReconnectAttempts": -1,
		"timeout": 10000,
		"auth": {
			"creds_file": "default.creds"
		}
	},
	"request_defaults": {
		"timeout": 5000,
		"maxMessages": -1,
		"maxWait": -1
	},
	"subscribe_prefix": ""
}
```

Spawnpoint was able to successfully connect and communicate over NATS. 